### PR TITLE
remove local branch git requirements from `pyproject.toml`

### DIFF
--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - remove_local_git_requirements
 
 jobs:
   build-n-publish:

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - remove_local_git_requirements
 
 jobs:
   build-n-publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
 [project.optional-dependencies]
 io = ["fsspec>=2024.3.0"]
 test = [
-	"cf-python @ git+https://github.com/davidhassell/cf-python.git@kerchunk-read",
-	"cfdm @ git+https://github.com/davidhassell/cfdm.git@pyfive-netcdf",
-	"pyfive @ git+https://github.com/NCAS-CMS/pyfive.git@pbtree2",
+	# "cf-python @ git+https://github.com/davidhassell/cf-python.git@kerchunk-read",
+	# "cfdm @ git+https://github.com/davidhassell/cfdm.git@pyfive-netcdf",
+	# "pyfive @ git+https://github.com/NCAS-CMS/pyfive.git@pbtree2",
 	"pytest>=8",
 	"pytest-cov>=5",
         "pytest-xdist",


### PR DESCRIPTION
These need to be removed since the PyPI package won't upload to PyPI. See [upload failure](https://github.com/NCAS-CMS/ppfive/actions/runs/25113145743/job/73592551983) that is indeed intended from PyPI since those are unsecired links that end up in package metadata.