### PR TITLE
Pin Pyfive >=1.1.2 and build wheels for OSX (Windows don't work)

### DIFF
--- a/.github/workflows/build-and-deploy-wheels-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-wheels-on-pypi.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - pin_Pyfive
 
 permissions:
   contents: read
@@ -21,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]  # windows-latest fails
 
     steps:
       - name: Checkout source

--- a/.github/workflows/build-and-deploy-wheels-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-wheels-on-pypi.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]  # macos-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/build-and-deploy-wheels-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-wheels-on-pypi.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - pin_Pyfive
 
 permissions:
   contents: read

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - python >=3.11
   - numpy >=1.24
   - fsspec >=2024.3.0
+  - pyfive >=1.1.2
   - pytest >=8
   - pytest-xdist
   - udunits2  # cf-python needs it
@@ -14,4 +15,3 @@ dependencies:
   - pip:
       - cf-python @ git+https://github.com/davidhassell/cf-python.git@kerchunk-read
       - cfdm @ git+https://github.com/davidhassell/cfdm.git@pyfive-netcdf
-      - pyfive @ git+https://github.com/NCAS-CMS/pyfive.git@pbtree2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,12 @@ authors = [
 dependencies = [
 	"cftime",
 	"numpy>=1.24",
-	"pyfive",
+	"pyfive>=1.1.2",
 ]
 
 [project.optional-dependencies]
 io = ["fsspec>=2024.3.0"]
 test = [
-	# "cf-python @ git+https://github.com/davidhassell/cf-python.git@kerchunk-read",
-	# "cfdm @ git+https://github.com/davidhassell/cfdm.git@pyfive-netcdf",
-	# "pyfive @ git+https://github.com/NCAS-CMS/pyfive.git@pbtree2",
 	"pytest>=8",
 	"pytest-cov>=5",
         "pytest-xdist",


### PR DESCRIPTION
@bnlawrence we are pinning to the latest Pyfive, and am also trying to see if we can build dedicated wheels for OSX and Windows.