### PR TITLE
Fix test Python 3.11

### DIFF
--- a/ppfive/core/variables.py
+++ b/ppfive/core/variables.py
@@ -436,8 +436,7 @@ def build_data_variable_index(records, reader, parallelism):
             # Reverse air_pressure axis
             reverse = LBVC == 8
 
-            print(z_keys_set)
-            z_levels = sorted(z_keys_set, reverse=reverse)
+            z_levels = sorted(z_keys_set, reverse=bool(reverse))
 
             t_steps = sorted({_t_key(r) for r in recs_split})
             z_index = {k: i for i, k in enumerate(z_levels)}

--- a/ppfive/core/variables.py
+++ b/ppfive/core/variables.py
@@ -436,6 +436,7 @@ def build_data_variable_index(records, reader, parallelism):
             # Reverse air_pressure axis
             reverse = LBVC == 8
 
+            print(z_keys_set)
             z_levels = sorted(z_keys_set, reverse=reverse)
 
             t_steps = sorted({_t_key(r) for r in recs_split})


### PR DESCRIPTION
This comes down to an implementation detail of CPython.

The `reverse` parameter to `sorted()` is specified to be a Python `bool`, but historically CPython's C implementation has varied in how it converts that argument internally.

### What happens in Python 3.11

In CPython 3.11, the implementation eventually converts `reverse` to a C integer using an API that requires an object implementing the integer protocol (effectively `PyLong_AsLong()` or equivalent).

A `numpy.bool_`:

* is truthy,
* behaves like a boolean in Python expressions,
* **does not** implement the integer conversion protocol in the way CPython 3.11 expects here.

So

```python
sorted(data, reverse=np.bool_(True))
```

fails with

```text
TypeError: 'numpy.bool' object cannot be interpreted as an integer
```

Wrapping it with

```python
reverse=bool(reverse)
```

creates a genuine Python `bool`, which CPython accepts.

### What changed in Python 3.12+

In 3.12, CPython changed the implementation of `list.sort()`/`sorted()` so that the `reverse` argument is converted using truth-value testing (`PyObject_IsTrue()`), rather than requiring an integer conversion.

Conceptually it now behaves like

```c
reverse = PyObject_IsTrue(obj);
```

instead of something equivalent to

```c
reverse = PyLong_AsLong(obj);
```

Since `numpy.bool_` defines truthiness perfectly well, it works.

### Why `bool(reverse)` is still a good idea

Even on 3.12+, I'd recommend

```python
sorted(z_keys_set, reverse=bool(reverse))
```

because:

* it documents that `reverse` is intended to be a Boolean flag,
* it normalizes NumPy, pandas, and other Boolean scalar types,
* it makes the code portable across Python versions.

### A quick demonstration

```python
import numpy as np

r = np.bool_(True)

type(r)
# numpy.bool_

bool(r)
# True

type(bool(r))
# bool
```

After the conversion, `sorted()` receives exactly the type its API is documented to expect.

-- ChatGPT  :grin: 
