### PR TITLE
Up version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "umfive"
-version = "0.2.0"
+version = "0.2.1"
 description = "PP/Fields reader with pyfive-style high-level API"
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
~I forgot to change~ to v0.2.1 - the bugfix release after name change, will rerun the PyPI deployment too.
EDIT: even better since this way we have smooth transition: umfive (ex-ppfive) 0.2.0 **and** umfive proper 0.2.1