### PR TITLE
change from ppdump to umdump in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ test = [
 ]
 
 [project.scripts]
-ppdump = "umfive.ppdump:main"
+ppdump = "umfive.umdump:main"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
A hangover from name changing, I suppose one wants to cut a new release for ppdump executable to actually work eh @davidhassell ?